### PR TITLE
Fix sorting of user selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _packages/*.*
 !_packages/*.zip
 
 node_modules/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ _packages/*.*
 !_packages/*.zip
 
 node_modules/
-.idea/

--- a/core/components/superboxselect/processors/types/users/getlist.class.php
+++ b/core/components/superboxselect/processors/types/users/getlist.class.php
@@ -81,7 +81,7 @@ class SuperboxselectUsersGetListProcessor extends modObjectGetListProcessor
                 'id:IN' => array_map('intval', explode('|', $id))
             ));
         }
-        $c->sortby('pagetitle', 'ASC');
+        $c->sortby($this->getProperty('defaultSortField'), $this->getProperty('defaultSortDirection'));
         return $c;
     }
 


### PR DESCRIPTION
This was still set to 'pagetitle', which (for me at least) broke the selector.